### PR TITLE
Fix: stylesheet_link_tagをstylesheet_pack_tagに変更

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,7 +6,7 @@ html
     meta[name="viewport" content="width=device-width,initial-scale=1"]
     = csrf_meta_tags
     = csp_meta_tag
-    = stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = stylesheet_pack_tag 'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
   body
     = yield


### PR DESCRIPTION
本番環境（heroku）でのみbootstrapのCSSが効かないエラーを修正。
[stackoverflow](https://stackoverflow.com/questions/58328026/css-and-bootstrap-not-loading-in-rails-6-app-when-deployed-to-heroku)を参考に、stylesheet_link_tagをstylesheet_pack_tagに変更。