### PR TITLE
Fix: WebpackerでCSSをコンパイルしないよう設定

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -84,10 +84,10 @@ production:
   <<: *default
 
   # Production depends on precompilation of packs prior to booting for performance.
-  compile: true
+  compile: false
 
   # Extract and emit a css file
-  extract_css: true
+  extract_css: false
 
   # Cache manifest.json for performance
   cache_manifest: true


### PR DESCRIPTION
以下記事を参考に修正
https://newbedev.com/webpacker-4-2-can-t-find-application-in-app-public-packs-manifest-json-heroku