### PR TITLE
08 add admin episodes controller

### DIFF
--- a/app/controllers/admin/episodes_controller.rb
+++ b/app/controllers/admin/episodes_controller.rb
@@ -1,0 +1,69 @@
+class Admin::EpisodesController < Admin::BaseController
+  before_action :set_episode, only: %i[ show edit update destroy ]
+
+  # GET /episodes or /episodes.json
+  def index
+    @episodes = Episode.all
+  end
+
+  # GET /episodes/1 or /episodes/1.json
+  def show
+  end
+
+  # GET /episodes/new
+  def new
+    @episode = Episode.new
+  end
+
+  # GET /episodes/1/edit
+  def edit
+  end
+
+  # POST /episodes or /episodes.json
+  def create
+    @episode = Episode.new(episode_params)
+
+    respond_to do |format|
+      if @episode.save
+        format.html { redirect_to [:admin, @episode], notice: "Episode was successfully created." }
+        format.json { render :show, status: :created, location: [:admin, @episode] }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @episode.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /episodes/1 or /episodes/1.json
+  def update
+    respond_to do |format|
+      if @episode.update(episode_params)
+        format.html { redirect_to [:admin, @episode], notice: "Episode was successfully updated." }
+        format.json { render :show, status: :ok, location: [:admin, @episode] }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @episode.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /episodes/1 or /episodes/1.json
+  def destroy
+    @episode.destroy
+    respond_to do |format|
+      format.html { redirect_to admin_episodes_url, notice: "Episode was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_episode
+      @episode = Episode.find(params[:id])
+    end
+
+    # Only allow a list of trusted parameters through.
+    def episode_params
+      params.require(:episode).permit(:onair_at)
+    end
+end

--- a/app/controllers/admin/episodes_controller.rb
+++ b/app/controllers/admin/episodes_controller.rb
@@ -36,8 +36,9 @@ class Admin::EpisodesController < Admin::BaseController
 
   # PATCH/PUT /episodes/1 or /episodes/1.json
   def update
+    @episode.assign_attributes(episode_params)
     respond_to do |format|
-      if @episode.update(episode_params)
+      if @episode.save
         format.html { redirect_to [:admin, @episode], notice: "Episode was successfully updated." }
         format.json { render :show, status: :ok, location: [:admin, @episode] }
       else
@@ -64,6 +65,6 @@ class Admin::EpisodesController < Admin::BaseController
 
     # Only allow a list of trusted parameters through.
     def episode_params
-      params.require(:episode).permit(:onair_at)
+      params.require(:episode).permit(:onair_at, candidate_ids: [])
     end
 end

--- a/app/views/admin/episodes/_episode.json.jbuilder
+++ b/app/views/admin/episodes/_episode.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! episode, :id, :onair_at, :created_at, :updated_at
+json.url episode_url(episode, format: :json)

--- a/app/views/admin/episodes/_form.html.slim
+++ b/app/views/admin/episodes/_form.html.slim
@@ -1,0 +1,12 @@
+= form_for [:admin, @episode] do |f|
+  - if @episode.errors.any?
+    #error_explanation
+      h2 = "#{pluralize(@episode.errors.count, 'error')} prohibited this episode from being saved:"
+      ul
+        - @episode.errors.full_messages.each do |message|
+          li = message
+
+  .field
+    = f.label :onair_at
+    = f.datetime_select :onair_at
+  .actions = f.submit

--- a/app/views/admin/episodes/_form.html.slim
+++ b/app/views/admin/episodes/_form.html.slim
@@ -7,6 +7,12 @@
           li = message
 
   .field
-    = f.label :onair_at
-    = f.datetime_select :onair_at
+    .form-group
+      = f.label :onair_at
+      = f.datetime_select :onair_at
+    .form-group
+      = f.label :candidate_ids, '出演者'
+      = f.collection_check_boxes :candidate_ids, Candidate.all, :id, :name do |candidate|
+        br
+        = candidate.label { candidate.check_box + candidate.text }
   .actions = f.submit

--- a/app/views/admin/episodes/edit.html.slim
+++ b/app/views/admin/episodes/edit.html.slim
@@ -1,0 +1,7 @@
+h1 Editing episode
+
+== render 'form'
+
+=> link_to 'Show', [:admin, @episode]
+'|
+=< link_to 'Back', admin_episodes_path

--- a/app/views/admin/episodes/index.html.slim
+++ b/app/views/admin/episodes/index.html.slim
@@ -1,0 +1,21 @@
+h1 Listing episodes
+
+table
+  thead
+    tr
+      th Onair at
+      th
+      th
+      th
+
+  tbody
+    - @episodes.each do |episode|
+      tr
+        td = episode.onair_at
+        td = link_to 'Show', [:admin, episode]
+        td = link_to 'Edit', edit_admin_episode_path(episode)
+        td = link_to 'Destroy', [:admin, episode], data: { confirm: 'Are you sure?' }, method: :delete
+
+br
+
+= link_to 'New Episode', new_admin_episode_path

--- a/app/views/admin/episodes/index.json.jbuilder
+++ b/app/views/admin/episodes/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @episodes, partial: "episodes/episode", as: :episode

--- a/app/views/admin/episodes/new.html.slim
+++ b/app/views/admin/episodes/new.html.slim
@@ -1,0 +1,5 @@
+h1 New episode
+
+== render 'form'
+
+= link_to 'Back', episodes_path

--- a/app/views/admin/episodes/show.html.slim
+++ b/app/views/admin/episodes/show.html.slim
@@ -1,0 +1,9 @@
+p#notice = notice
+
+p
+  strong Onair at:
+  = @episode.onair_at
+
+=> link_to 'Edit', edit_admin_episode_path(@episode)
+'|
+=< link_to 'Back', admin_episodes_path

--- a/app/views/admin/episodes/show.json.jbuilder
+++ b/app/views/admin/episodes/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "episodes/episode", episode: @episode

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root 'home#index'
   namespace :admin do
     resources :candidates
+    resources :episodes
   end
   namespace :api, format: 'json' do
     resources :sessions, only: %i(create destroy)

--- a/db/migrate/20211113233610_add_index_to_candidates_episodes.rb
+++ b/db/migrate/20211113233610_add_index_to_candidates_episodes.rb
@@ -1,0 +1,5 @@
+class AddIndexToCandidatesEpisodes < ActiveRecord::Migration[6.1]
+  def change
+    add_index :candidates_episodes, [:candidate_id, :episode_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_09_114133) do
+ActiveRecord::Schema.define(version: 2021_11_13_233610) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,6 +38,7 @@ ActiveRecord::Schema.define(version: 2021_11_09_114133) do
     t.bigint "episode_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["candidate_id", "episode_id"], name: "index_candidates_episodes_on_candidate_id_and_episode_id", unique: true
     t.index ["candidate_id"], name: "index_candidates_episodes_on_candidate_id"
     t.index ["episode_id"], name: "index_candidates_episodes_on_episode_id"
   end


### PR DESCRIPTION
・CandidatesEpisodesモデルにおいて、candidate_idとepisode_idの組み合わせの一意性を保証
・ Admin::EpisodesControllerを作成し、#editで所有する候補者を編集できるよう実装