### PR TITLE
Add: 候補者のBET数の算出ロジックを簡潔化。BEST3だけでなく全員のBET数を表示するよう変更

### DIFF
--- a/app/controllers/api/candidates_controller.rb
+++ b/app/controllers/api/candidates_controller.rb
@@ -3,7 +3,7 @@ class Api::CandidatesController < ApplicationController
 
   def index
     candidates = Candidate.all
-    render json: candidates
+    render json: candidates, methods: [:votes]
   end
 
   def ranking

--- a/app/javascript/pages/top/index.vue
+++ b/app/javascript/pages/top/index.vue
@@ -37,14 +37,14 @@
           :to="{ name: 'RegisterIndex' }"
           class="btn btn-dark m-3 router-link-active"
         ) ユーザー登録
-    h3.my-3 みんなの予想BEST3
-    div(v-for="(value, key) in candidateRanking")
-      p {{ key }}  {{ value }}票
+    h3.my-3 みんなの予想ランキング
+    template(v-for="candidate in candidates")
+      p {{ summary(candidate) }} {{ candidate.votes }}票
 </template>
 
 <script>
 import TheYoutube from '../../components/TheYoutube.vue'
-import { mapGetters } from 'vuex'
+import { mapActions, mapGetters } from 'vuex'
 export default {
   name: 'TopIndex',
   components: { TheYoutube },
@@ -54,22 +54,13 @@ export default {
     }
   },
   created() {
-    this.fetchCandidatesRanking()
+    this.fetchCandidates()
   },
   computed: {
     ...mapGetters('users', ['authUser']),
-    ...mapGetters('candidates', ['summary'])
+    ...mapGetters('candidates', ['candidates', 'summary'])
   },
-  methods: {
-    async fetchCandidatesRanking() {
-      try {
-        const res = await this.$axios.get('candidates/ranking')
-        this.candidateRanking = res.data
-      } catch(error) {
-        console.log(error)
-      }
-    }
-  }
+  methods: {...mapActions('candidates', ['fetchCandidates'])}
 }
 </script>
 

--- a/app/javascript/store/modules/candidates.js
+++ b/app/javascript/store/modules/candidates.js
@@ -7,7 +7,7 @@ const candidates = {
   },
   getters: {
     candidates: state => {
-      return state.candidates
+      return state.candidates.sort((first, second) => second.votes - first.votes )
     },
     identifier: (_state) => (url) => {
       return url.split('/').slice(-1)[0]

--- a/app/models/candidate.rb
+++ b/app/models/candidate.rb
@@ -8,5 +8,7 @@ class Candidate < ApplicationRecord
   validates :title, presence: true, length: { maximum: 255 }
   validates :youtube_url, presence: true
 
-  scope :best3, -> { joins(:bettings).group("candidates.name").order(count_all: :desc).limit(3).count }
+  def votes
+    bettings.count
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,7 @@ Rails.application.routes.draw do
       get 'name_index', on: :collection
     end
     resources :bettings, only: %i(create)
-    resources :candidates, only: %i(index) do
-      get 'ranking', on: :collection
-    end
+    resources :candidates, only: %i(index)
   end
   get '*path', to: 'home#index'
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html


### PR DESCRIPTION
候補者のBET数ランキングの算出を、RailsのスコープからVueのゲッターズで処理する方法に変更。
またランキングはBEST3だけでなく全員表示するよう変更。