### PR TITLE
Fix: pushStateの第一引数を修正

### DIFF
--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -48,7 +48,7 @@ const router = new VueRouter({
   ]
 })
 
-router.beforeEach((to, from, next) =>{
+router.beforeEach((to, _from, next) =>{
   store.dispatch('users/fetchAuthUser').then((authUser) => {
     if (to.matched.some(record => record.meta.requireAuth) && !authUser) {
       next({ name: 'LoginIndex' });
@@ -56,7 +56,7 @@ router.beforeEach((to, from, next) =>{
       next();
     }
   }),
-  history.pushState(from, '')
+  history.pushState(null, '', null)
 })
 
 export default router


### PR DESCRIPTION
pushStateの第一引数にfromを入れたところ、ログイン後のトップページでエラーが発生したため、
[記事](https://blog.maxpace.tech/browser-back-history-popstate/#toc2)を参考に引数をnullに修正