### PR TITLE
Add: 成績画像のみ読み込み方法を変更

### DIFF
--- a/app/javascript/components/TheStatus.vue
+++ b/app/javascript/components/TheStatus.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
   #status.text-center.my-5
     h1.text-center.fw-bold.text-white 成績
-    img.w-50(src="/assets/status.svg")
+    img.w-50(src="~status.svg")
     template(v-if="authUser.current_candidate")
       .row.row-cols-1.row-cols-md-2
         .col.m-auto
@@ -21,6 +21,7 @@
 </template>
 
 <script>
+import 'status.svg'
 import TheYoutube from './TheYoutube.vue'
 import { mapGetters } from 'vuex'
 export default {

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -11,6 +11,7 @@ default: &default
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
   additional_paths: []
+  resolved_paths: ['app/assets/images']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false


### PR DESCRIPTION
herokuでのみ画像を読み込めない問題を解消するため、
[WebpackerのREADME](https://github.com/rails/webpacker/tree/3-x-stable#resolved)を参考に画像の読み込み方法を変更。
まずは成績画面の画像のみ変更しテスト。